### PR TITLE
Add receiveTime and redefine captureTime for remote sources

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -80,7 +80,8 @@ to determine if frames were missed between VideoFrameRequestCallbacks.
 ::  For video frames coming from either a local or remote source, this is the
 time at which the frame was captured by the camera. For a remote source, the
 capture time is estimated using clock synchronization and RTCP sender reports
-as specified in <a href="https://tools.ietf.org/html/rfc3550#section-6.4.1">RFC 3550 Section 6.4.1</a>.
+to convert RTP timestamps to capture time as specified in
+<a href="https://tools.ietf.org/html/rfc3550#section-6.4.1">RFC 3550 Section 6.4.1</a>.
 
 : <dfn for="VideoFrameMetadata" attribute>receiveTime</dfn>
 ::  For video frames coming from a remote source, this is the

--- a/index.bs
+++ b/index.bs
@@ -41,6 +41,7 @@ This section has not been written yet. Please refer to <a href="https://github.c
     double elapsedProcessingTime;
     unsigned long presentedFrames;
     DOMHighResTimeStamp captureTime;
+    DOMHighResTimeStamp receiveTime;
     unsigned long rtpTimestamp;
   };
 </pre>
@@ -77,10 +78,15 @@ to determine if frames were missed between VideoFrameRequestCallbacks.
 
 : <dfn for="VideoFrameMetadata" attribute>captureTime</dfn>
 ::  For video frames coming from either a local or remote source, this is the
+time at which the frame was captured by the camera. For a remote source, the
+capture time is estimated using clock synchronization and RTCP sender reports
+as specified in <a href="https://tools.ietf.org/html/rfc3550#section-6.4.1">RFC 3550 Section 6.4.1</a>.
+
+: <dfn for="VideoFrameMetadata" attribute>receiveTime</dfn>
+::  For video frames coming from a remote source, this is the
 time the encoded packet with the same presentationTimestamp as this frame
-was received by the platform. E.g., for a local camera, this is the time
-at which the frame was captured by the camera. For a remote source, this
-would be the time at which the packet was received over the network.
+was received by the platform, i.e., the time at which all packets belonging
+to this frame was received over the network.
 
 : <dfn for="VideoFrameMetadata" attribute>rtpTimestamp</dfn>
 ::  The RTP timestamp associated with this video frame.

--- a/index.bs
+++ b/index.bs
@@ -85,9 +85,8 @@ to convert RTP timestamps to capture time as specified in
 
 : <dfn for="VideoFrameMetadata" attribute>receiveTime</dfn>
 ::  For video frames coming from a remote source, this is the
-time the encoded packet with the same presentationTimestamp as this frame
-was received by the platform, i.e., the time at which all packets belonging
-to this frame was received over the network.
+time the encoded frame was received by the platform, i.e., the time at
+which the last packet belonging to this frame was received over the network.
 
 : <dfn for="VideoFrameMetadata" attribute>rtpTimestamp</dfn>
 ::  The RTP timestamp associated with this video frame.


### PR DESCRIPTION
This way, captureTime will be what the name suggests and receiveTime is used
to maintain the information about receive times that was previously accessed
through captureTime for remote sources.