### PR TITLE
Update Explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -81,12 +81,6 @@ partial interface HTMLVideoElement {
     unsigned long requestAnimationFrame(VideoFrameRequestCallback callback);
     void cancelAnimationFrame(unsigned long handle);
 };
-
-partial interface WebGLVideoTexture {
-    // Allows DOM-less WebGL usage where texImage2D() is the only compositor to
-    // avoid the need for requestAnimationFrame() to get video frame metadata.
-    VideoFrameMetadata VideoElementTargetVideoTexture(GLenum target, HTMLVideoElement video)
-}
 ```
 
 
@@ -119,14 +113,13 @@ Presented frame 0s (1280x720) at 1000ms for display at 1016ms.
 
 
 # Implementation Details
-* When texImage2D() or drawImage() is called during an active VideoFrameRequestCallback, implementations shall ensure that the video frame used is the one matching the active callback.
 * Just like window.requestAnimationFrame(), callbacks are one-shot. video.requestAnimationFrame() must be called again to get the next frame.
+* VideoFrameRequestCallbacks are run as part of the "[update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering)" portion of the event loop model, before window.requestAnimationFrame() callbacks are run.
 * Since VideoFrameRequestCallback will only occur on new frames, error states may never satisfy the requestAnimationFrame.
 * In cases where VideoFrameMetadata can't be surfaced (e.g., [encrypted media](https://w3c.github.io/encrypted-media/#media-element-restrictions)) implementations may never satisfy the requestAnimationFrame.
 
 
 # Open Questions / Notes / Links
-* The API as proposed will miss some frames when compositing happens off the main thread if a subsequent video.requestAnimationFrame() call does not happen in time. To rectify this we would need to make callbacks repeating.
 * [Link to GitHub repository.](https://github.com/WICG/video-raf)
 * [Link to WICG Discourse.](https://discourse.wicg.io/t/proposal-video-requestanimationframe/3691)
 * [Link to TAG review.](https://github.com/w3ctag/design-reviews/issues/429)

--- a/explainer.md
+++ b/explainer.md
@@ -113,11 +113,19 @@ Presented frame 0s (1280x720) at 1000ms for display at 1016ms.
 
 
 # Implementation Details
-* Just like window.requestAnimationFrame(), callbacks are one-shot. video.requestAnimationFrame() must be called again to get the next frame.
-* VideoFrameRequestCallbacks are run before window.requestAnimationFrame() callbacks, during the "[update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering)" steps.
-* window.requestAnimationFrame() callbacks registered from within a video.requestAnimationFrame() callback will be run in the same turn of the event loop.
-* Since VideoFrameRequestCallback will only occur on new frames, error states may never satisfy the requestAnimationFrame.
-* In cases where VideoFrameMetadata can't be surfaced (e.g., [encrypted media](https://w3c.github.io/encrypted-media/#media-element-restrictions)) implementations may never satisfy the requestAnimationFrame.
+* Just like `window.requestAnimationFrame()`, callbacks are one-shot. `video.requestAnimationFrame()` must be called again to get the next frame.
+* Since `VideoFrameRequestCallback` will only occur on new frames, error states may never satisfy the requestAnimationFrame.
+* In cases where `VideoFrameMetadata` can't be surfaced (e.g., [encrypted media](https://w3c.github.io/encrypted-media/#media-element-restrictions)) implementations may never satisfy the requestAnimationFrame.
+* `VideoFrameRequestCallbacks` are run before `window.requestAnimationFrame()` callbacks, during the "[update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering)" steps.
+* `window.requestAnimationFrame()` callbacks registered from within a `video.requestAnimationFrame()` callback will be run in the same turn of the event loop. E.g:
+```Javascript
+  video.requestAnimationFrame(vid_now => {
+    window.requestAnimationFrame(win_now => {
+        if (vid_now != win_now)
+            throw "This should never throw";
+    });
+  });
+```
 
 
 # Open Questions / Notes / Links

--- a/explainer.md
+++ b/explainer.md
@@ -114,7 +114,8 @@ Presented frame 0s (1280x720) at 1000ms for display at 1016ms.
 
 # Implementation Details
 * Just like window.requestAnimationFrame(), callbacks are one-shot. video.requestAnimationFrame() must be called again to get the next frame.
-* VideoFrameRequestCallbacks are run as part of the "[update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering)" portion of the event loop model, before window.requestAnimationFrame() callbacks are run.
+* VideoFrameRequestCallbacks are run before window.requestAnimationFrame() callbacks, during the "[update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering)" steps.
+* window.requestAnimationFrame() callbacks registered from within a video.requestAnimationFrame() callback will be run in the same turn of the event loop.
 * Since VideoFrameRequestCallback will only occur on new frames, error states may never satisfy the requestAnimationFrame.
 * In cases where VideoFrameMetadata can't be surfaced (e.g., [encrypted media](https://w3c.github.io/encrypted-media/#media-element-restrictions)) implementations may never satisfy the requestAnimationFrame.
 

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/video-raf/" rel="canonical">
-  <meta content="d15ee27115ea6660613a2268c8679d1a28fbd6e7" name="document-revision">
+  <meta content="8c9247a985eac36c7359e83f24c983c5cd648c94" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec


### PR DESCRIPTION
This change:
- removes the reference to the partial interface (see #2).
- removes the notes mentioning that implementations shall ensure that the current video frame matches the active callback (relevant to #3)
- adds execution timing details relative to window.rAF, and along with a small example.