### PR TITLE
Define width/height and presentationTime units

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -52,15 +52,23 @@ This method allows web authors to register a callback which will run the next ti
 : <dfn for="VideoFrameMetadata" dict-member>expectedPresentationTime</dfn>
 :: The time at which the user agent expects the frame to be visible.
 
+Note: <dfn>media pixels</dfn> refers to the raw media pixels, after internal
+cropping, but before aspect ratio adjustments. This differs from CSS pixels
+(used by {{HTMLVideoElement/videoWidth|videoWidth}} and
+{{HTMLVideoElement/videoHeight|videoHeight}}), which account for aspect ratio
+adjustments. The {{width}} and {{height}} in [=media pixels=] can be used as a
+texture's width and height when calling <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D">`texImage2D()`</a>.
+
 : <dfn for="VideoFrameMetadata" dict-member>width</dfn>
-:: The width of the video frame.
+:: The width of the video frame, in [=media pixels=].
 
 : <dfn for="VideoFrameMetadata" dict-member>height</dfn>
-:: The height of the video frame.
+:: The height of the video frame, in [=media pixels=].
 
 : <dfn for="VideoFrameMetadata" dict-member>presentationTimestamp</dfn>
-::  The presentation timestamp in seconds of the frame presented. May not be known
-  to the compositor or exist in all cases.
+::  The media presentation timestamp in seconds of the frame presented (e.g. its
+  timestamp on the {{HTMLMediaElement/currentTime|video.currentTime}} timeline).
+  May not be known to the compositor or exist in all cases.
 
 : <dfn for="VideoFrameMetadata" dict-member>elapsedProcessingTime</dfn>
 ::  The elapsed time in seconds from submission of the encoded packet with

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/video-raf/" rel="canonical">
-  <meta content="d0dc2aac5640a224d5a1819dfed7b436b5136cb0" name="document-revision">
+  <meta content="890b8bbb44e550d198857a2966bada2d63c5ba0b" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1482,7 +1482,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">HTMLVideoElement.requestAnimationFrame()</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-14">14 February 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-20">20 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1581,16 +1581,24 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-expectedpresentationtime"><code>expectedPresentationTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑤">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>The time at which the user agent expects the frame to be visible.</p>
+   </dl>
+   <p class="note" role="note"><span>Note:</span> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="media-pixels">media pixels</dfn> refers to the raw media pixels, after internal
+cropping, but before aspect ratio adjustments. This differs from CSS pixels
+(used by <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth" id="ref-for-dom-video-videowidth">videoWidth</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight" id="ref-for-dom-video-videoheight">videoHeight</a></code>), which account for aspect ratio
+adjustments. The <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width①">width</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height①">height</a></code> in <a data-link-type="dfn" href="#media-pixels" id="ref-for-media-pixels">media pixels</a> can be used as a
+texture’s width and height when calling <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D"><code>texImage2D()</code></a>.</p>
+   <dl>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-width"><code>width</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④">unsigned long</a></span>
     <dd data-md>
-     <p>The width of the video frame.</p>
+     <p>The width of the video frame, in <a data-link-type="dfn" href="#media-pixels" id="ref-for-media-pixels①">media pixels</a>.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-height"><code>height</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤">unsigned long</a></span>
     <dd data-md>
-     <p>The height of the video frame.</p>
+     <p>The height of the video frame, in <a data-link-type="dfn" href="#media-pixels" id="ref-for-media-pixels②">media pixels</a>.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-presentationtimestamp"><code>presentationTimestamp</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②">double</a></span>
     <dd data-md>
-     <p>The presentation timestamp in seconds of the frame presented. May not be known
-to the compositor or exist in all cases.</p>
+     <p>The media presentation timestamp in seconds of the frame presented (e.g. its
+timestamp on the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime" id="ref-for-dom-media-currenttime">video.currentTime</a></code> timeline).
+May not be known to the compositor or exist in all cases.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-elapsedprocessingtime"><code>elapsedProcessingTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a></span>
     <dd data-md>
      <p>The elapsed time in seconds from submission of the encoded packet with
@@ -1842,6 +1850,7 @@ which the last packet belonging to this frame was received over the network.</p>
    <li><a href="#dom-videoframemetadata-expectedpresentationtime">expectedPresentationTime</a><span>, in §2.1</span>
    <li><a href="#dom-videoframemetadata-height">height</a><span>, in §2.1</span>
    <li><a href="#list-of-animation-frame-callbacks">list of animation frame callbacks</a><span>, in §4.1</span>
+   <li><a href="#media-pixels">media pixels</a><span>, in §2.1</span>
    <li><a href="#dom-videoframemetadata-presentationtime">presentationTime</a><span>, in §2.1</span>
    <li><a href="#dom-videoframemetadata-presentationtimestamp">presentationTimestamp</a><span>, in §2.1</span>
    <li><a href="#dom-videoframemetadata-presentedframes">presentedFrames</a><span>, in §2.1</span>
@@ -1876,6 +1885,12 @@ which the last packet belonging to this frame was received over the network.</p>
     <li><a href="#ref-for-htmlvideoelement⑤">4.2. Procedures</a> <a href="#ref-for-htmlvideoelement⑥">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-media-currenttime">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-media-currenttime">2.1. Attributes</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-event-loop-processing-model">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model</a><b>Referenced in:</b>
    <ul>
@@ -1892,6 +1907,18 @@ which the last packet belonging to this frame was received over the network.</p>
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">1. Introduction</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-video-videoheight">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-video-videoheight">2.1. Attributes</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-video-videowidth">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-video-videowidth">2.1. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-double">
@@ -1927,9 +1954,12 @@ which the last packet belonging to this frame was received over the network.</p>
     <ul>
      <li><span class="dfn-paneled" id="term-for-animationframeprovider" style="color:initial">AnimationFrameProvider</span>
      <li><span class="dfn-paneled" id="term-for-htmlvideoelement" style="color:initial">HTMLVideoElement</span>
+     <li><span class="dfn-paneled" id="term-for-dom-media-currenttime" style="color:initial">currentTime</span>
      <li><span class="dfn-paneled" id="term-for-event-loop-processing-model" style="color:initial">event loop processing model</span>
      <li><span class="dfn-paneled" id="term-for-report-the-exception" style="color:initial">report the exception</span>
      <li><span class="dfn-paneled" id="term-for-update-the-rendering" style="color:initial">update the rendering</span>
+     <li><span class="dfn-paneled" id="term-for-dom-video-videoheight" style="color:initial">videoHeight</span>
+     <li><span class="dfn-paneled" id="term-for-dom-video-videowidth" style="color:initial">videoWidth</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
@@ -1956,8 +1986,8 @@ which the last packet belonging to this frame was received over the network.</p>
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑨"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentationtime" id="ref-for-dom-videoframemetadata-presentationtime①"><c- g>presentationTime</c-></a>;
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-expectedpresentationtime" id="ref-for-dom-videoframemetadata-expectedpresentationtime①"><c- g>expectedPresentationTime</c-></a>;
 
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width①"><c- g>width</c-></a>;
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height①"><c- g>height</c-></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width②"><c- g>width</c-></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height②"><c- g>height</c-></a>;
 
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp①"><c- g>presentationTimestamp</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-elapsedprocessingtime" id="ref-for-dom-videoframemetadata-elapsedprocessingtime①"><c- g>elapsedProcessingTime</c-></a>;
@@ -1999,16 +2029,24 @@ which the last packet belonging to this frame was received over the network.</p>
     <li><a href="#ref-for-dom-videoframemetadata-expectedpresentationtime">2. VideoFrameMetadata</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="media-pixels">
+   <b><a href="#media-pixels">#media-pixels</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-media-pixels">2.1. Attributes</a> <a href="#ref-for-media-pixels①">(2)</a> <a href="#ref-for-media-pixels②">(3)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-width">
    <b><a href="#dom-videoframemetadata-width">#dom-videoframemetadata-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-width">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-width①">2.1. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-height">
    <b><a href="#dom-videoframemetadata-height">#dom-videoframemetadata-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-height">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-height①">2.1. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-presentationtimestamp">


### PR DESCRIPTION
This PR tentatively defines "media pixels" for the width and height members of the VideoFrameMetadata, as discussed in #4.

It also clarifies the unit/timeline of presentationTimestamp, as discussed in #11.