### PR TITLE
Update intro and add note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,7 @@ Markup Shorthands: markdown yes
   spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html
     type: dfn
       text: run the animation frame callbacks; url: #run-the-animation-frame-callbacks
+    type:attribute; for:CanvasRenderingContext2D; text:canvas
   spec: css-values; urlPrefix: https://drafts.csswg.org/css-values/
     type: dfn
       text: CSS pixels; url: #px
@@ -40,7 +41,24 @@ Markup Shorthands: markdown yes
 
 This is a proposal to add a {{AnimationFrameProvider|requestAnimationFrame()}} method to the {{HTMLVideoElement}}.
 
-This method allows web authors to register a {{VideoFrameRequestCallback}} which runs after a new frame is presented for composition. The {{VideoFrameRequestCallback|callbacks}} are executed immediately before {{FrameRequestCallback|FrameRequestCallbacks}} registered through {{AnimationFrameProvider|window.requestAnimationFrame()}}, during the "[=update the rendering=]" portion of the [=event loop processing model=]. The {{VideoFrameRequestCallback}} also provides useful {{VideoFrameMetadata|metadata}} about the video frame that was most recently presented for composition.
+This method allows web authors to register a {{VideoFrameRequestCallback|callback}} which runs in the
+[=update the rendering|rendering steps=], when a new video frame is sent to the compositor. The
+new {{VideoFrameRequestCallback|callbacks}} are executed immediately before existing
+{{AnimationFrameProvider|window.requestAnimationFrame()}} callbacks. Changes made from within both callback types within the same [=event loop processing model|turn of the event loop=] will be visible on screen at the same time, with the next v-sync.
+
+Drawing operations (e.g. drawing a video frame to a {{canvas}} via {{drawImage()}}) made through this
+API will be synchronized as a *best effort* with the video playing on screen. *Best effort* in this case
+means that, even with a normal work load, a {{VideoFrameRequestCallback|callback}} can occasionally be
+fired one v-sync late, relative to when the new video frame was presented. This means that drawing
+operations might occasionally appear on screen one v-sync after the video frame does. Additionally, if
+there is a heavy load on the main thread, we might not get a callback for every frame (as measured by a
+discontinuity in the {{presentedFrames}}).
+
+Note: A web author could know if a callback is late by checking whether {{expectedDisplayTime}} is equal
+to *now*, as opposed to roughly one v-sync in the future.
+
+The {{VideoFrameRequestCallback}} also provides useful {{VideoFrameMetadata|metadata}} about the video
+frame that was most recently presented for composition, which can be used for automated metrics analysis.
 
 # VideoFrameMetadata #    {#video-frame-metadata}
 
@@ -122,7 +140,7 @@ have rectangular pixels). When a calling
 # VideoFrameRequestCallback #    {#video-frame-request-callback}
 
 <pre class='idl'>
-  callback VideoFrameRequestCallback = void(DOMHighResTimeStamp time, VideoFrameMetadata metadata);
+  callback VideoFrameRequestCallback = void(DOMHighResTimeStamp now, VideoFrameMetadata metadata);
 </pre>
 
 Each {{VideoFrameRequestCallback}} object has a <dfn>canceled</dfn> boolean initially set to false.
@@ -201,6 +219,18 @@ To <dfn>run the video animation frame callbacks</dfn> for a {{HTMLVideoElement}}
   1. If the entry's [=canceled=] boolean is <code>true</code>, continue to the next entry.
   1. [=Invoke=] the callback, passing |now| and |metadata| as arguments
   1. If an exception is thrown, [=report the exception=].
+
+Note: There are **no strict timing guarantees** when it comes to how soon
+{{VideoFrameRequestCallback|callbacks}} are run after a new video frame has been presented.
+Consider the following scenario: a new frame is presented on the compositor thread, just as the user
+agent aborts the [=run the video animation frame callbacks|algorithm=] above, when it confirms that
+there are no new frames. We therefore won't run the {{VideoFrameRequestCallback|callbacks}} in the
+*current* [=update the rendering|rendering steps=], and have to wait until the *next* [=update the
+rendering|rendering steps=], one v-sync later. In that case, visual changes to a web page made from
+within the delayed {{VideoFrameRequestCallback|callbacks}} will appear on-screen one v-sync after the
+video frame does.<br/>
+<br/>
+Offering stricter guarantees would likely force implementers to add cross-thread synchronization, which might be detrimental to video playback performance.
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -1570,7 +1570,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp"><c- g>presentationTimestamp</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-elapsedprocessingtime" id="ref-for-dom-videoframemetadata-elapsedprocessingtime"><c- g>elapsedProcessingTime</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes"><c- g>presentedFrames</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①"><c- g>presentedFrames</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime"><c- g>captureTime</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime"><c- g>receiveTime</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-rtptimestamp" id="ref-for-dom-videoframemetadata-rtptimestamp"><c- g>rtpTimestamp</c-></a>;
@@ -1631,7 +1631,7 @@ which the last packet belonging to this frame was received over the network.</p>
      <p>The RTP timestamp associated with this video frame.</p>
    </dl>
    <h2 class="heading settled" data-level="3" id="video-frame-request-callback"><span class="secno">3. </span><span class="content">VideoFrameRequestCallback</span><a class="self-link" href="#video-frame-request-callback"></a></h2>
-<pre class="idl highlight def"><c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-videoframerequestcallback"><code><c- g>VideoFrameRequestCallback</c-></code></dfn> = <c- b>void</c->(<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑧"><c- n>DOMHighResTimeStamp</c-></a> <dfn class="idl-code" data-dfn-for="VideoFrameRequestCallback" data-dfn-type="argument" data-export id="dom-videoframerequestcallback-time"><code><c- g>time</c-></code><a class="self-link" href="#dom-videoframerequestcallback-time"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata①"><c- n>VideoFrameMetadata</c-></a> <dfn class="idl-code" data-dfn-for="VideoFrameRequestCallback" data-dfn-type="argument" data-export id="dom-videoframerequestcallback-metadata"><code><c- g>metadata</c-></code><a class="self-link" href="#dom-videoframerequestcallback-metadata"></a></dfn>);
+<pre class="idl highlight def"><c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-videoframerequestcallback"><code><c- g>VideoFrameRequestCallback</c-></code></dfn> = <c- b>void</c->(<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑧"><c- n>DOMHighResTimeStamp</c-></a> <dfn class="idl-code" data-dfn-for="VideoFrameRequestCallback" data-dfn-type="argument" data-export id="dom-videoframerequestcallback-now"><code><c- g>now</c-></code><a class="self-link" href="#dom-videoframerequestcallback-now"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata①"><c- n>VideoFrameMetadata</c-></a> <dfn class="idl-code" data-dfn-for="VideoFrameRequestCallback" data-dfn-type="argument" data-export id="dom-videoframerequestcallback-metadata"><code><c- g>metadata</c-></code><a class="self-link" href="#dom-videoframerequestcallback-metadata"></a></dfn>);
 </pre>
    <p>Each <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback④">VideoFrameRequestCallback</a></code> object has a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="canceled">canceled</dfn> boolean initially set to false.</p>
    <h2 class="heading settled" data-level="4" id="video-raf"><span class="secno">4. </span><span class="content">HTMLVideoElement.requestAnimationFrame()</span><a class="self-link" href="#video-raf"></a></h2>
@@ -1702,7 +1702,7 @@ where and how to invoke the algorithm in the meantime.</p>
      <li data-md>
       <p>Let <var>metadata</var> be the <code class="idl"><a data-link-type="idl" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata②">VideoFrameMetadata</a></code> dictionary built from <var>video</var>’s latest presented frame.</p>
      <li data-md>
-      <p>Let <var>presentedFrames</var> be the value of <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①">presentedFrames</a></code> field.</p>
+      <p>Let <var>presentedFrames</var> be the value of <var>metadata</var>’s <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes②">presentedFrames</a></code> field.</p>
      <li data-md>
       <p>If the <a data-link-type="dfn" href="#last-presented-frame-indentifier" id="ref-for-last-presented-frame-indentifier">last presented frame indentifier</a> is equal to <var>presentedFrames</var>, abort these steps.</p>
      <li data-md>
@@ -1722,6 +1722,12 @@ where and how to invoke the algorithm in the meantime.</p>
         <p>If an exception is thrown, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception" id="ref-for-report-the-exception">report the exception</a>.</p>
       </ol>
     </ol>
+    <p class="note" role="note"><span>Note:</span> There are <strong>no strict timing guarantees</strong> when it comes to how soon <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑦">callbacks</a></code> are run after a new video frame has been presented.
+Consider the following scenario: a new frame is presented on the compositor thread, just as the user
+agent aborts the <a data-link-type="dfn" href="#run-the-video-animation-frame-callbacks" id="ref-for-run-the-video-animation-frame-callbacks②">algorithm</a> above, when it confirms that
+there are no new frames. We therefore won’t run the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑧">callbacks</a></code> in the <em>current</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering④">rendering steps</a>, and have to wait until the <em>next</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering⑤">rendering steps</a>, one v-sync later. In that case, visual changes to a web page made from
+within the delayed <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑨">callbacks</a></code> will appear on-screen one v-sync after the
+video frame does.<br> <br> Offering stricter guarantees would likely force implementers to add cross-thread synchronization, which might be detrimental to video playback performance.</p>
    </div>
    <h2 class="heading settled" data-level="5" id="security-and-privacy"><span class="secno">5. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
    <p>This specification does not expose any new privacy-sensitive information. However, the location
@@ -1952,12 +1958,6 @@ therefore be coarse enough not to facilitate timing attacks.</p>
     <li><a href="#ref-for-animationframeprovider">1. Introduction</a> <a href="#ref-for-animationframeprovider①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-framerequestcallback">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#framerequestcallback">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#framerequestcallback</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-framerequestcallback">1. Introduction</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
    <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
@@ -1967,10 +1967,22 @@ therefore be coarse enough not to facilitate timing attacks.</p>
     <li><a href="#ref-for-htmlvideoelement⑥">4.2. Procedures</a> <a href="#ref-for-htmlvideoelement⑦">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-canvas">
+   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#canvas">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#canvas</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-canvas">1. Introduction</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-dom-media-currenttime">
    <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-currenttime">2.2. Attributes</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-context-2d-drawimage">
+   <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-context-2d-drawimage">1. Introduction</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-event-loop-processing-model">
@@ -2001,7 +2013,7 @@ therefore be coarse enough not to facilitate timing attacks.</p>
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">1. Introduction</a>
-    <li><a href="#ref-for-update-the-rendering①">4.2. Procedures</a> <a href="#ref-for-update-the-rendering②">(2)</a> <a href="#ref-for-update-the-rendering③">(3)</a>
+    <li><a href="#ref-for-update-the-rendering①">4.2. Procedures</a> <a href="#ref-for-update-the-rendering②">(2)</a> <a href="#ref-for-update-the-rendering③">(3)</a> <a href="#ref-for-update-the-rendering④">(4)</a> <a href="#ref-for-update-the-rendering⑤">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-video-videoheight">
@@ -2070,9 +2082,10 @@ therefore be coarse enough not to facilitate timing attacks.</p>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-animationframeprovider" style="color:initial">AnimationFrameProvider</span>
-     <li><span class="dfn-paneled" id="term-for-framerequestcallback" style="color:initial">FrameRequestCallback</span>
      <li><span class="dfn-paneled" id="term-for-htmlvideoelement" style="color:initial">HTMLVideoElement</span>
+     <li><span class="dfn-paneled" id="term-for-canvas" style="color:initial">canvas</span>
      <li><span class="dfn-paneled" id="term-for-dom-media-currenttime" style="color:initial">currentTime</span>
+     <li><span class="dfn-paneled" id="term-for-dom-context-2d-drawimage" style="color:initial">drawImage(image, dx, dy, dw, dh)</span>
      <li><span class="dfn-paneled" id="term-for-event-loop-processing-model" style="color:initial">event loop processing model</span>
      <li><span class="dfn-paneled" id="term-for-fully-active" style="color:initial">fully active</span>
      <li><span class="dfn-paneled" id="term-for-report-the-exception" style="color:initial">report the exception</span>
@@ -2127,13 +2140,13 @@ therefore be coarse enough not to facilitate timing attacks.</p>
 
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp①"><c- g>presentationTimestamp</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-elapsedprocessingtime" id="ref-for-dom-videoframemetadata-elapsedprocessingtime②"><c- g>elapsedProcessingTime</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes②"><c- g>presentedFrames</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①①"><c- g>presentedFrames</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime④"><c- g>captureTime</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime④"><c- g>receiveTime</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-rtptimestamp" id="ref-for-dom-videoframemetadata-rtptimestamp②"><c- g>rtpTimestamp</c-></a>;
 };
 
-<c- b>callback</c-> <a href="#callbackdef-videoframerequestcallback"><code><c- g>VideoFrameRequestCallback</c-></code></a> = <c- b>void</c->(<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑧①"><c- n>DOMHighResTimeStamp</c-></a> <a href="#dom-videoframerequestcallback-time"><code><c- g>time</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata①①"><c- n>VideoFrameMetadata</c-></a> <a href="#dom-videoframerequestcallback-metadata"><code><c- g>metadata</c-></code></a>);
+<c- b>callback</c-> <a href="#callbackdef-videoframerequestcallback"><code><c- g>VideoFrameRequestCallback</c-></code></a> = <c- b>void</c->(<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑧①"><c- n>DOMHighResTimeStamp</c-></a> <a href="#dom-videoframerequestcallback-now"><code><c- g>now</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata①①"><c- n>VideoFrameMetadata</c-></a> <a href="#dom-videoframerequestcallback-metadata"><code><c- g>metadata</c-></code></a>);
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement①①"><c- g>HTMLVideoElement</c-></a> {
     <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="method" href="#dom-htmlvideoelement-requestanimationframe" id="ref-for-dom-htmlvideoelement-requestanimationframe①"><c- g>requestAnimationFrame</c-></a>(<a class="n" data-link-type="idl-name" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑤①"><c- n>VideoFrameRequestCallback</c-></a> <a href="#dom-htmlvideoelement-requestanimationframe-callback-callback"><code><c- g>callback</c-></code></a>);
@@ -2205,8 +2218,9 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
   <aside class="dfn-panel" data-for="dom-videoframemetadata-presentedframes">
    <b><a href="#dom-videoframemetadata-presentedframes">#dom-videoframemetadata-presentedframes</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-videoframemetadata-presentedframes">2. VideoFrameMetadata</a>
-    <li><a href="#ref-for-dom-videoframemetadata-presentedframes①">4.2. Procedures</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentedframes">1. Introduction</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentedframes①">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentedframes②">4.2. Procedures</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-capturetime">
@@ -2286,7 +2300,7 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
   <aside class="dfn-panel" data-for="run-the-video-animation-frame-callbacks">
    <b><a href="#run-the-video-animation-frame-callbacks">#run-the-video-animation-frame-callbacks</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-run-the-video-animation-frame-callbacks">4.2. Procedures</a> <a href="#ref-for-run-the-video-animation-frame-callbacks①">(2)</a>
+    <li><a href="#ref-for-run-the-video-animation-frame-callbacks">4.2. Procedures</a> <a href="#ref-for-run-the-video-animation-frame-callbacks①">(2)</a> <a href="#ref-for-run-the-video-animation-frame-callbacks②">(3)</a>
    </ul>
   </aside>
 <script>/* script-var-click-highlighting */


### PR DESCRIPTION
Clarifies the language in the intro, and calls out the lack of timing guarantees in the intro, and in a note close following the "run the video animation frame callbacks" algorithm.