### PR TITLE
Rename attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,14 +66,14 @@ frame that was most recently presented for composition, which can be used for au
 
 <pre class='idl'>
   dictionary VideoFrameMetadata {
-    required DOMHighResTimeStamp timePresented;
+    required DOMHighResTimeStamp presentedTime;
     required DOMHighResTimeStamp expectedDisplayTime;
 
     required unsigned long width;
     required unsigned long height;
 
     double presentationTimestamp;
-    double elapsedProcessingTime;
+    double processingDuration;
     unsigned long presentedFrames;
     DOMHighResTimeStamp captureTime;
     DOMHighResTimeStamp receiveTime;
@@ -89,7 +89,7 @@ adjustments.
 
 ## Attributes ## {#video-frame-metadata-attributes}
 
-: <dfn for="VideoFrameMetadata" dict-member>timePresented</dfn>
+: <dfn for="VideoFrameMetadata" dict-member>presentedTime</dfn>
 :: The time at which the user agent submitted the frame for composition.
 
 : <dfn for="VideoFrameMetadata" dict-member>expectedDisplayTime</dfn>
@@ -114,8 +114,8 @@ be used to determine the aspect ratio to use, when using the texture.
   timestamp on the {{HTMLMediaElement/currentTime|video.currentTime}} timeline).
   May not be known to the compositor or exist in all cases.
 
-: <dfn for="VideoFrameMetadata" dict-member>elapsedProcessingTime</dfn>
-::  The elapsed time in seconds from submission of the encoded packet with
+: <dfn for="VideoFrameMetadata" dict-member>processingDuration</dfn>
+::  The elapsed duration in seconds from submission of the encoded packet with
   the same presentationTimestamp as this frame to the decoder until the
   decoded frame was ready for presentation.
 
@@ -249,7 +249,7 @@ give indication as to how far the peers are located, and can give some location 
 if the location of the other peer is known. Since this information is already available via the
 [[webrtc-stats|RTCStats]], this specification doesn't introduce any novel privacy considerations.
 
-This specification might introduce some new GPU fingerprinting opportunities. {{elapsedProcessingTime}}
+This specification might introduce some new GPU fingerprinting opportunities. {{processingDuration}}
 exposes some under-the-hood performance information about the video pipeline, which is otherwise
 inaccessible to web developers. Using this information, one could correlate the performance of various
 codecs and video sizes to a known GPU's profile. We therefore propose a resolution of 100μs, which is
@@ -261,7 +261,7 @@ codecs, which don't yet have widespread hardware decoding support. However, rath
 profiles themselves, one could directly get equivalent information from getting the
 {{MediaCapabilitiesInfo}}.
 
-This specification also introduces some new timing information. {{timePresented}} and
+This specification also introduces some new timing information. {{presentedTime}} and
 {{expectedDisplayTime}} expose compositor timing information; {{captureTime}} and
 {{receiveTime}} expose network timing information. The [=clock resolution=] of these fields should
 therefore be coarse enough not to facilitate timing attacks.

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/video-raf/" rel="canonical">
-  <meta content="244aebd22705618c477e1cf7751d4885099a29bf" name="document-revision">
+  <meta content="86bdbab2440d684e99885a7f0671b0d06fb2575e" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1581,14 +1581,14 @@ to <em>now</em>, as opposed to roughly one v-sync in the future.</p>
 frame that was most recently presented for composition, which can be used for automated metrics analysis.</p>
    <h2 class="heading settled" data-level="2" id="video-frame-metadata"><span class="secno">2. </span><span class="content">VideoFrameMetadata</span><a class="self-link" href="#video-frame-metadata"></a></h2>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-videoframemetadata"><code><c- g>VideoFrameMetadata</c-></code></dfn> {
-  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-timepresented" id="ref-for-dom-videoframemetadata-timepresented"><c- g>timePresented</c-></a>;
+  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentedtime" id="ref-for-dom-videoframemetadata-presentedtime"><c- g>presentedTime</c-></a>;
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime①"><c- g>expectedDisplayTime</c-></a>;
 
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width"><c- g>width</c-></a>;
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height"><c- g>height</c-></a>;
 
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp"><c- g>presentationTimestamp</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-elapsedprocessingtime" id="ref-for-dom-videoframemetadata-elapsedprocessingtime"><c- g>elapsedProcessingTime</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-processingduration" id="ref-for-dom-videoframemetadata-processingduration"><c- g>processingDuration</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①"><c- g>presentedFrames</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime"><c- g>captureTime</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime"><c- g>receiveTime</c-></a>;
@@ -1601,7 +1601,7 @@ ratio adjustments. They are different from <a data-link-type="dfn" href="https:/
 adjustments.</p>
    <h3 class="heading settled" data-level="2.2" id="video-frame-metadata-attributes"><span class="secno">2.2. </span><span class="content">Attributes</span><a class="self-link" href="#video-frame-metadata-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-timepresented"><code>timePresented</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④">DOMHighResTimeStamp</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-presentedtime"><code>presentedTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>The time at which the user agent submitted the frame for composition.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-expecteddisplaytime"><code>expectedDisplayTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑤">DOMHighResTimeStamp</a></span>
@@ -1624,9 +1624,9 @@ be used to determine the aspect ratio to use, when using the texture.</p>
      <p>The media presentation timestamp in seconds of the frame presented (e.g. its
 timestamp on the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime" id="ref-for-dom-media-currenttime">video.currentTime</a></code> timeline).
 May not be known to the compositor or exist in all cases.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-elapsedprocessingtime"><code>elapsedProcessingTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-processingduration"><code>processingDuration</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a></span>
     <dd data-md>
-     <p>The elapsed time in seconds from submission of the encoded packet with
+     <p>The elapsed duration in seconds from submission of the encoded packet with
 the same presentationTimestamp as this frame to the decoder until the
 decoded frame was ready for presentation.</p>
     <dd data-md>
@@ -1757,7 +1757,7 @@ true for this spec: <code class="idl"><a data-link-type="idl" href="#dom-videofr
 information which can be correlated to location information. E.g., reusing the same example, <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime②">captureTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime②">receiveTime</a></code> can be used to estimate network end-to-end travel time, which can
 give indication as to how far the peers are located, and can give some location information about a peer
 if the location of the other peer is known. Since this information is already available via the <a data-link-type="biblio" href="#biblio-webrtc-stats">RTCStats</a>, this specification doesn’t introduce any novel privacy considerations.</p>
-   <p>This specification might introduce some new GPU fingerprinting opportunities. <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-elapsedprocessingtime" id="ref-for-dom-videoframemetadata-elapsedprocessingtime①">elapsedProcessingTime</a></code> exposes some under-the-hood performance information about the video pipeline, which is otherwise
+   <p>This specification might introduce some new GPU fingerprinting opportunities. <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-processingduration" id="ref-for-dom-videoframemetadata-processingduration①">processingDuration</a></code> exposes some under-the-hood performance information about the video pipeline, which is otherwise
 inaccessible to web developers. Using this information, one could correlate the performance of various
 codecs and video sizes to a known GPU’s profile. We therefore propose a resolution of 100μs, which is
 still useful for automated quality analysis, but doesn’t offer any new sources of high resolution
@@ -1766,7 +1766,7 @@ between hardware and software decoders to infer information about a GPU’s feat
 would make it easier to fingerprint the newest GPUs, which have hardware decoders for the latest
 codecs, which don’t yet have widespread hardware decoding support. However, rather than measuring the
 profiles themselves, one could directly get equivalent information from getting the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/media-capabilities#dictdef-mediacapabilitiesinfo" id="ref-for-dictdef-mediacapabilitiesinfo">MediaCapabilitiesInfo</a></code>.</p>
-   <p>This specification also introduces some new timing information. <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-timepresented" id="ref-for-dom-videoframemetadata-timepresented①">timePresented</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime②">expectedDisplayTime</a></code> expose compositor timing information; <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime③">captureTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime③">receiveTime</a></code> expose network timing information. The <a data-link-type="dfn" href="https://w3c.github.io/hr-time/#clock-resolution" id="ref-for-clock-resolution">clock resolution</a> of these fields should
+   <p>This specification also introduces some new timing information. <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-presentedtime" id="ref-for-dom-videoframemetadata-presentedtime①">presentedTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime②">expectedDisplayTime</a></code> expose compositor timing information; <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime③">captureTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime③">receiveTime</a></code> expose network timing information. The <a data-link-type="dfn" href="https://w3c.github.io/hr-time/#clock-resolution" id="ref-for-clock-resolution">clock resolution</a> of these fields should
 therefore be coarse enough not to facilitate timing attacks.</p>
    <h2 class="heading settled" data-level="6" id="examples"><span class="secno">6. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="example-drawing"><span class="secno">6.1. </span><span class="content">Drawing frames at the video rate</span><a class="self-link" href="#example-drawing"></a></h3>
@@ -1963,7 +1963,6 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
    <li><a href="#dom-htmlvideoelement-cancelanimationframe">cancelAnimationFrame(handle)</a><span>, in §4.1</span>
    <li><a href="#canceled">canceled</a><span>, in §3</span>
    <li><a href="#dom-videoframemetadata-capturetime">captureTime</a><span>, in §2.2</span>
-   <li><a href="#dom-videoframemetadata-elapsedprocessingtime">elapsedProcessingTime</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-expecteddisplaytime">expectedDisplayTime</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-height">height</a><span>, in §2.2</span>
    <li><a href="#last-presented-frame-indentifier">last presented frame indentifier</a><span>, in §4.1</span>
@@ -1971,11 +1970,12 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
    <li><a href="#media-pixels">media pixels</a><span>, in §2.1</span>
    <li><a href="#dom-videoframemetadata-presentationtimestamp">presentationTimestamp</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-presentedframes">presentedFrames</a><span>, in §2.2</span>
+   <li><a href="#dom-videoframemetadata-presentedtime">presentedTime</a><span>, in §2.2</span>
+   <li><a href="#dom-videoframemetadata-processingduration">processingDuration</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-receivetime">receiveTime</a><span>, in §2.2</span>
    <li><a href="#dom-htmlvideoelement-requestanimationframe">requestAnimationFrame(callback)</a><span>, in §4.1</span>
    <li><a href="#dom-videoframemetadata-rtptimestamp">rtpTimestamp</a><span>, in §2.2</span>
    <li><a href="#run-the-video-animation-frame-callbacks">run the video animation frame callbacks</a><span>, in §4.2</span>
-   <li><a href="#dom-videoframemetadata-timepresented">timePresented</a><span>, in §2.2</span>
    <li><a href="#dictdef-videoframemetadata">VideoFrameMetadata</a><span>, in §2</span>
    <li><a href="#callbackdef-videoframerequestcallback">VideoFrameRequestCallback</a><span>, in §3</span>
    <li><a href="#dom-videoframemetadata-width">width</a><span>, in §2.2</span>
@@ -2195,14 +2195,14 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>dictionary</c-> <a href="#dictdef-videoframemetadata"><code><c- g>VideoFrameMetadata</c-></code></a> {
-  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑨"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-timepresented" id="ref-for-dom-videoframemetadata-timepresented②"><c- g>timePresented</c-></a>;
+  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑨"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentedtime" id="ref-for-dom-videoframemetadata-presentedtime②"><c- g>presentedTime</c-></a>;
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime①①"><c- g>expectedDisplayTime</c-></a>;
 
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width③"><c- g>width</c-></a>;
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height③"><c- g>height</c-></a>;
 
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp①"><c- g>presentationTimestamp</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-elapsedprocessingtime" id="ref-for-dom-videoframemetadata-elapsedprocessingtime②"><c- g>elapsedProcessingTime</c-></a>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-processingduration" id="ref-for-dom-videoframemetadata-processingduration②"><c- g>processingDuration</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①①"><c- g>presentedFrames</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime④"><c- g>captureTime</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime④"><c- g>receiveTime</c-></a>;
@@ -2237,11 +2237,11 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
     <li><a href="#ref-for-media-pixels">2.2. Attributes</a> <a href="#ref-for-media-pixels①">(2)</a> <a href="#ref-for-media-pixels②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-timepresented">
-   <b><a href="#dom-videoframemetadata-timepresented">#dom-videoframemetadata-timepresented</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-videoframemetadata-presentedtime">
+   <b><a href="#dom-videoframemetadata-presentedtime">#dom-videoframemetadata-presentedtime</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-videoframemetadata-timepresented">2. VideoFrameMetadata</a>
-    <li><a href="#ref-for-dom-videoframemetadata-timepresented①">5. Security and Privacy Considerations</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentedtime">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentedtime①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-expecteddisplaytime">
@@ -2272,11 +2272,11 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
     <li><a href="#ref-for-dom-videoframemetadata-presentationtimestamp">2. VideoFrameMetadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-elapsedprocessingtime">
-   <b><a href="#dom-videoframemetadata-elapsedprocessingtime">#dom-videoframemetadata-elapsedprocessingtime</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-videoframemetadata-processingduration">
+   <b><a href="#dom-videoframemetadata-processingduration">#dom-videoframemetadata-processingduration</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-videoframemetadata-elapsedprocessingtime">2. VideoFrameMetadata</a>
-    <li><a href="#ref-for-dom-videoframemetadata-elapsedprocessingtime①">5. Security and Privacy Considerations</a>
+    <li><a href="#ref-for-dom-videoframemetadata-processingduration">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-processingduration①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-presentedframes">


### PR DESCRIPTION
This PR addresses some of the issues in #42.

It renames timePresented to presentedTime to be consistent
with other attributes having 'time' at the end.

It also changes elapsedProcessingTime to processingDuration, since
the field denotes a time delta and not a timestamp.