### PR TITLE
Update attributes name and requirements

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -27,15 +27,15 @@ dictionary VideoFrameMetadata {
     required DOMHighResTimeStamp presentationTime;
 
     // The time at which the user agent expects the frame to be visible.
-    required DOMHighResTimeStamp expectedPresentationTime;
+    required DOMHighResTimeStamp expectedDisplayTime;
 
     // The width and height of the presented video frame.
     required unsigned long width;
     required unsigned long height;
 
-    // The presentation timestamp in seconds of the frame presented. May not be
-    // known to the compositor or exist in all cases.
-    double presentationTimestamp;  // optional
+    // The media presentation timestamp in seconds of the frame presented. This
+    // should match the value of `video.currentTime` when the frame is displayed
+    double mediaTime;
 
     // The elapsed time in seconds from submission of the encoded packet with
     // the same presentationTimestamp as this frame to the decoder until the
@@ -43,7 +43,7 @@ dictionary VideoFrameMetadata {
     //
     // In addition to decoding time, may include processing time. E.g., YUV
     // conversion and/or staging into GPU backed memory.
-    double elapsedProcessingTime;  // optional
+    double processingDuration;  // optional
 
     // A count of the number of frames submitted for composition. Allows clients
     // to determine if frames were missed between VideoFrameRequestCallbacks.
@@ -51,22 +51,22 @@ dictionary VideoFrameMetadata {
     // https://wiki.whatwg.org/wiki/Video_Metrics#presentedFrames
     unsigned long presentedFrames;  // optional
 
-    // For video frames coming from either a local or remote source, this is the
-    // time the encoded packet with the same presentationTimestamp as this frame
-    // was received by the platform. E.g., for a local camera, this is the time
-    // at which the frame was captured by the camera. For a remote source, this
-    // would be the time at which the packet was received over the network.
-    //
-    // TODO: For remote sources should this instead be an estimate of the
-    // capture time on the remote endpoint?
+    // For video frames coming from either a local or remote source, this is
+    // the time at which the frame was captured by the camera. For a remote
+    // source, the capture time is estimated using clock synchronization and
+    // RTCP sender reports to convert RTP timestamps to capture time as
+    // specified in RFC 3550 Section 6.4.1.
     DOMHighResTimeStamp captureTime;  // optional
+
+    // For video frames coming from a remote source, this is the time the
+    // encoded frame was received by the platform, i.e., the time at which the
+    // last packet belonging to this frame was received over the network.
+    DOMHighResTimeStamp receiveTime; // optional
 
     // The RTP timestamp associated with this video frame.
     //
     // https://w3c.github.io/webrtc-pc/#dom-rtcrtpcontributingsource
     unsigned long rtpTimestamp;  // optional
-
-    // Potentially other useful properties?
 };
 
 callback VideoFrameRequestCallback = void(DOMHighResTimeStamp time, VideoFrameMetadata);

--- a/index.bs
+++ b/index.bs
@@ -66,15 +66,16 @@ frame that was most recently presented for composition, which can be used for au
 
 <pre class='idl'>
   dictionary VideoFrameMetadata {
-    required DOMHighResTimeStamp presentedTime;
+    required DOMHighResTimeStamp presentationTime;
     required DOMHighResTimeStamp expectedDisplayTime;
 
     required unsigned long width;
     required unsigned long height;
+    required double mediaTime;
 
-    double presentationTimestamp;
+    required unsigned long presentedFrames;
     double processingDuration;
-    unsigned long presentedFrames;
+
     DOMHighResTimeStamp captureTime;
     DOMHighResTimeStamp receiveTime;
     unsigned long rtpTimestamp;
@@ -89,7 +90,7 @@ adjustments.
 
 ## Attributes ## {#video-frame-metadata-attributes}
 
-: <dfn for="VideoFrameMetadata" dict-member>presentedTime</dfn>
+: <dfn for="VideoFrameMetadata" dict-member>presentationTime</dfn>
 :: The time at which the user agent submitted the frame for composition.
 
 : <dfn for="VideoFrameMetadata" dict-member>expectedDisplayTime</dfn>
@@ -109,37 +110,48 @@ have rectangular pixels). When a calling
 while {{HTMLVideoElement/videoWidth|videoWidth}} and {{HTMLVideoElement/videoHeight|videoHeight}} can
 be used to determine the aspect ratio to use, when using the texture.
 
-: <dfn for="VideoFrameMetadata" dict-member>presentationTimestamp</dfn>
-::  The media presentation timestamp in seconds of the frame presented (e.g. its
-  timestamp on the {{HTMLMediaElement/currentTime|video.currentTime}} timeline).
-  May not be known to the compositor or exist in all cases.
+: <dfn for="VideoFrameMetadata" dict-member>mediaTime</dfn>
+::  The media presentation timestamp (PTS) in seconds of the frame presented (e.g.
+  its timestamp on the {{HTMLMediaElement/currentTime|video.currentTime}} timeline).
+  MAY have a zero value for live-streams or WebRTC application.
+
+: <dfn for="VideoFrameMetadata" dict-member>presentedFrames</dfn>
+::  A count of the number of frames submitted for composition. Allows clients
+  to determine if frames were missed between {{VideoFrameRequestCallback}}s. MUST be monotonically
+  increasing.
 
 : <dfn for="VideoFrameMetadata" dict-member>processingDuration</dfn>
-::  The elapsed duration in seconds from submission of the encoded packet with
-  the same presentationTimestamp as this frame to the decoder until the
-  decoded frame was ready for presentation.
+::  The elapsed duration in seconds from submission of the encoded packet with the same
+  presentation timestamp (PTS) as this frame (e.g. same as the {{mediaTime}}) to the decoder
+  until the decoded frame was ready for presentation.
 
 :: In addition to decoding time, may include processing time. E.g., YUV
   conversion and/or staging into GPU backed memory.
 
-: <dfn for="VideoFrameMetadata" dict-member>presentedFrames</dfn>
-::  A count of the number of frames submitted for composition. Allows clients
-  to determine if frames were missed between {{VideoFrameRequestCallback}}s.
+:: SHOULD be present. In some cases, user-agents might not be able to surface this information since
+  portions of the media pipeline might be owned by the OS.
 
 : <dfn for="VideoFrameMetadata" dict-member>captureTime</dfn>
 ::  For video frames coming from either a local or remote source, this is the
   time at which the frame was captured by the camera. For a remote source, the
   capture time is estimated using clock synchronization and RTCP sender reports
   to convert RTP timestamps to capture time as specified in
-  [[RFC3550#section-6.4.1|RFC 3550 Section 6.4.1]]
+  [[RFC3550#section-6.4.1|RFC 3550 Section 6.4.1]].
+
+:: SHOULD be present for WebRTC applications, and absent otherwise.
 
 : <dfn for="VideoFrameMetadata" dict-member>receiveTime</dfn>
 ::  For video frames coming from a remote source, this is the
   time the encoded frame was received by the platform, i.e., the time at
   which the last packet belonging to this frame was received over the network.
 
+:: SHOULD be present for WebRTC applications that receive data from a remote source,
+  and absent otherwise.
+
 : <dfn for="VideoFrameMetadata" dict-member>rtpTimestamp</dfn>
 ::  The RTP timestamp associated with this video frame.
+
+:: SHOULD be present for WebRTC applications, and absent otherwise.
 
 # VideoFrameRequestCallback #    {#video-frame-request-callback}
 
@@ -261,7 +273,7 @@ codecs, which don't yet have widespread hardware decoding support. However, rath
 profiles themselves, one could directly get equivalent information from getting the
 {{MediaCapabilitiesInfo}}.
 
-This specification also introduces some new timing information. {{presentedTime}} and
+This specification also introduces some new timing information. {{presentationTime}} and
 {{expectedDisplayTime}} expose compositor timing information; {{captureTime}} and
 {{receiveTime}} expose network timing information. The [=clock resolution=] of these fields should
 therefore be coarse enough not to facilitate timing attacks.

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/video-raf/" rel="canonical">
-  <meta content="86bdbab2440d684e99885a7f0671b0d06fb2575e" name="document-revision">
+  <meta content="eae931a6c0d22618a7859a6c64d95a6ec5b26c00" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1482,7 +1482,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">HTMLVideoElement.requestAnimationFrame()</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-03-25">25 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-03-30">30 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1581,15 +1581,16 @@ to <em>now</em>, as opposed to roughly one v-sync in the future.</p>
 frame that was most recently presented for composition, which can be used for automated metrics analysis.</p>
    <h2 class="heading settled" data-level="2" id="video-frame-metadata"><span class="secno">2. </span><span class="content">VideoFrameMetadata</span><a class="self-link" href="#video-frame-metadata"></a></h2>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-videoframemetadata"><code><c- g>VideoFrameMetadata</c-></code></dfn> {
-  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentedtime" id="ref-for-dom-videoframemetadata-presentedtime"><c- g>presentedTime</c-></a>;
+  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentationtime" id="ref-for-dom-videoframemetadata-presentationtime"><c- g>presentationTime</c-></a>;
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime①"><c- g>expectedDisplayTime</c-></a>;
 
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width"><c- g>width</c-></a>;
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height"><c- g>height</c-></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-mediatime" id="ref-for-dom-videoframemetadata-mediatime"><c- g>mediaTime</c-></a>;
 
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp"><c- g>presentationTimestamp</c-></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①"><c- g>presentedFrames</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-processingduration" id="ref-for-dom-videoframemetadata-processingduration"><c- g>processingDuration</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①"><c- g>presentedFrames</c-></a>;
+
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime"><c- g>captureTime</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime"><c- g>receiveTime</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-rtptimestamp" id="ref-for-dom-videoframemetadata-rtptimestamp"><c- g>rtpTimestamp</c-></a>;
@@ -1601,7 +1602,7 @@ ratio adjustments. They are different from <a data-link-type="dfn" href="https:/
 adjustments.</p>
    <h3 class="heading settled" data-level="2.2" id="video-frame-metadata-attributes"><span class="secno">2.2. </span><span class="content">Attributes</span><a class="self-link" href="#video-frame-metadata-attributes"></a></h3>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-presentedtime"><code>presentedTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④">DOMHighResTimeStamp</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-presentationtime"><code>presentationTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp④">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>The time at which the user agent submitted the frame for composition.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-expecteddisplaytime"><code>expectedDisplayTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑤">DOMHighResTimeStamp</a></span>
@@ -1619,37 +1620,48 @@ have rectangular pixels). When a calling <a href="https://developer.mozilla.org/
 while <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth" id="ref-for-dom-video-videowidth①">videoWidth</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight" id="ref-for-dom-video-videoheight①">videoHeight</a></code> can
 be used to determine the aspect ratio to use, when using the texture.</p>
    <dl>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-presentationtimestamp"><code>presentationTimestamp</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②">double</a></span>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-mediatime"><code>mediaTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②">double</a></span>
     <dd data-md>
-     <p>The media presentation timestamp in seconds of the frame presented (e.g. its
-timestamp on the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime" id="ref-for-dom-media-currenttime">video.currentTime</a></code> timeline).
-May not be known to the compositor or exist in all cases.</p>
-    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-processingduration"><code>processingDuration</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a></span>
-    <dd data-md>
-     <p>The elapsed duration in seconds from submission of the encoded packet with
-the same presentationTimestamp as this frame to the decoder until the
-decoded frame was ready for presentation.</p>
-    <dd data-md>
-     <p>In addition to decoding time, may include processing time. E.g., YUV
-conversion and/or staging into GPU backed memory.</p>
+     <p>The media presentation timestamp (PTS) in seconds of the frame presented (e.g.
+its timestamp on the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime" id="ref-for-dom-media-currenttime">video.currentTime</a></code> timeline).
+MAY have a zero value for live-streams or WebRTC application.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-presentedframes"><code>presentedFrames</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥">unsigned long</a></span>
     <dd data-md>
      <p>A count of the number of frames submitted for composition. Allows clients
-to determine if frames were missed between <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback④">VideoFrameRequestCallback</a></code>s.</p>
+to determine if frames were missed between <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback④">VideoFrameRequestCallback</a></code>s. MUST be monotonically
+increasing.</p>
+    <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-processingduration"><code>processingDuration</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a></span>
+    <dd data-md>
+     <p>The elapsed duration in seconds from submission of the encoded packet with the same
+presentation timestamp (PTS) as this frame (e.g. same as the <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-mediatime" id="ref-for-dom-videoframemetadata-mediatime①">mediaTime</a></code>) to the decoder
+until the decoded frame was ready for presentation.</p>
+    <dd data-md>
+     <p>In addition to decoding time, may include processing time. E.g., YUV
+conversion and/or staging into GPU backed memory.</p>
+    <dd data-md>
+     <p>SHOULD be present. In some cases, user-agents might not be able to surface this information since
+portions of the media pipeline might be owned by the OS.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-capturetime"><code>captureTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑥">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>For video frames coming from either a local or remote source, this is the
 time at which the frame was captured by the camera. For a remote source, the
 capture time is estimated using clock synchronization and RTCP sender reports
-to convert RTP timestamps to capture time as specified in <a href="https://tools.ietf.org/html/rfc3550#section-6.4.1">RFC 3550 Section 6.4.1</a></p>
+to convert RTP timestamps to capture time as specified in <a href="https://tools.ietf.org/html/rfc3550#section-6.4.1">RFC 3550 Section 6.4.1</a>.</p>
+    <dd data-md>
+     <p>SHOULD be present for WebRTC applications, and absent otherwise.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-receivetime"><code>receiveTime</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑦">DOMHighResTimeStamp</a></span>
     <dd data-md>
      <p>For video frames coming from a remote source, this is the
 time the encoded frame was received by the platform, i.e., the time at
 which the last packet belonging to this frame was received over the network.</p>
+    <dd data-md>
+     <p>SHOULD be present for WebRTC applications that receive data from a remote source,
+and absent otherwise.</p>
     <dt data-md><dfn class="dfn-paneled idl-code" data-dfn-for="VideoFrameMetadata" data-dfn-type="dict-member" data-export id="dom-videoframemetadata-rtptimestamp"><code>rtpTimestamp</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦">unsigned long</a></span>
     <dd data-md>
      <p>The RTP timestamp associated with this video frame.</p>
+    <dd data-md>
+     <p>SHOULD be present for WebRTC applications, and absent otherwise.</p>
    </dl>
    <h2 class="heading settled" data-level="3" id="video-frame-request-callback"><span class="secno">3. </span><span class="content">VideoFrameRequestCallback</span><a class="self-link" href="#video-frame-request-callback"></a></h2>
 <pre class="idl highlight def"><c- b>callback</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="callback" data-export id="callbackdef-videoframerequestcallback"><code><c- g>VideoFrameRequestCallback</c-></code></dfn> = <c- b>void</c->(<a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑧"><c- n>DOMHighResTimeStamp</c-></a> <dfn class="idl-code" data-dfn-for="VideoFrameRequestCallback" data-dfn-type="argument" data-export id="dom-videoframerequestcallback-now"><code><c- g>now</c-></code><a class="self-link" href="#dom-videoframerequestcallback-now"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata①"><c- n>VideoFrameMetadata</c-></a> <dfn class="idl-code" data-dfn-for="VideoFrameRequestCallback" data-dfn-type="argument" data-export id="dom-videoframerequestcallback-metadata"><code><c- g>metadata</c-></code><a class="self-link" href="#dom-videoframerequestcallback-metadata"></a></dfn>);
@@ -1766,7 +1778,7 @@ between hardware and software decoders to infer information about a GPU’s feat
 would make it easier to fingerprint the newest GPUs, which have hardware decoders for the latest
 codecs, which don’t yet have widespread hardware decoding support. However, rather than measuring the
 profiles themselves, one could directly get equivalent information from getting the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/media-capabilities#dictdef-mediacapabilitiesinfo" id="ref-for-dictdef-mediacapabilitiesinfo">MediaCapabilitiesInfo</a></code>.</p>
-   <p>This specification also introduces some new timing information. <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-presentedtime" id="ref-for-dom-videoframemetadata-presentedtime①">presentedTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime②">expectedDisplayTime</a></code> expose compositor timing information; <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime③">captureTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime③">receiveTime</a></code> expose network timing information. The <a data-link-type="dfn" href="https://w3c.github.io/hr-time/#clock-resolution" id="ref-for-clock-resolution">clock resolution</a> of these fields should
+   <p>This specification also introduces some new timing information. <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-presentationtime" id="ref-for-dom-videoframemetadata-presentationtime①">presentationTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime②">expectedDisplayTime</a></code> expose compositor timing information; <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime③">captureTime</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime③">receiveTime</a></code> expose network timing information. The <a data-link-type="dfn" href="https://w3c.github.io/hr-time/#clock-resolution" id="ref-for-clock-resolution">clock resolution</a> of these fields should
 therefore be coarse enough not to facilitate timing attacks.</p>
    <h2 class="heading settled" data-level="6" id="examples"><span class="secno">6. </span><span class="content">Examples</span><a class="self-link" href="#examples"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="example-drawing"><span class="secno">6.1. </span><span class="content">Drawing frames at the video rate</span><a class="self-link" href="#example-drawing"></a></h3>
@@ -1968,9 +1980,9 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
    <li><a href="#last-presented-frame-indentifier">last presented frame indentifier</a><span>, in §4.1</span>
    <li><a href="#list-of-animation-frame-callbacks">list of animation frame callbacks</a><span>, in §4.1</span>
    <li><a href="#media-pixels">media pixels</a><span>, in §2.1</span>
-   <li><a href="#dom-videoframemetadata-presentationtimestamp">presentationTimestamp</a><span>, in §2.2</span>
+   <li><a href="#dom-videoframemetadata-mediatime">mediaTime</a><span>, in §2.2</span>
+   <li><a href="#dom-videoframemetadata-presentationtime">presentationTime</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-presentedframes">presentedFrames</a><span>, in §2.2</span>
-   <li><a href="#dom-videoframemetadata-presentedtime">presentedTime</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-processingduration">processingDuration</a><span>, in §2.2</span>
    <li><a href="#dom-videoframemetadata-receivetime">receiveTime</a><span>, in §2.2</span>
    <li><a href="#dom-htmlvideoelement-requestanimationframe">requestAnimationFrame(callback)</a><span>, in §4.1</span>
@@ -2195,15 +2207,16 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>dictionary</c-> <a href="#dictdef-videoframemetadata"><code><c- g>VideoFrameMetadata</c-></code></a> {
-  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑨"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentedtime" id="ref-for-dom-videoframemetadata-presentedtime②"><c- g>presentedTime</c-></a>;
+  <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp⑨"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-presentationtime" id="ref-for-dom-videoframemetadata-presentationtime②"><c- g>presentationTime</c-></a>;
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp①①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-expecteddisplaytime" id="ref-for-dom-videoframemetadata-expecteddisplaytime①①"><c- g>expectedDisplayTime</c-></a>;
 
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-width" id="ref-for-dom-videoframemetadata-width③"><c- g>width</c-></a>;
   <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-height" id="ref-for-dom-videoframemetadata-height③"><c- g>height</c-></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-mediatime" id="ref-for-dom-videoframemetadata-mediatime②"><c- g>mediaTime</c-></a>;
 
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-presentationtimestamp" id="ref-for-dom-videoframemetadata-presentationtimestamp①"><c- g>presentationTimestamp</c-></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①①"><c- g>presentedFrames</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><c- b>double</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="double " href="#dom-videoframemetadata-processingduration" id="ref-for-dom-videoframemetadata-processingduration②"><c- g>processingDuration</c-></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-presentedframes" id="ref-for-dom-videoframemetadata-presentedframes①①"><c- g>presentedFrames</c-></a>;
+
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-capturetime" id="ref-for-dom-videoframemetadata-capturetime④"><c- g>captureTime</c-></a>;
   <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp③①"><c- n>DOMHighResTimeStamp</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="DOMHighResTimeStamp " href="#dom-videoframemetadata-receivetime" id="ref-for-dom-videoframemetadata-receivetime④"><c- g>receiveTime</c-></a>;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="dict-member" data-type="unsigned long " href="#dom-videoframemetadata-rtptimestamp" id="ref-for-dom-videoframemetadata-rtptimestamp②"><c- g>rtpTimestamp</c-></a>;
@@ -2237,11 +2250,11 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
     <li><a href="#ref-for-media-pixels">2.2. Attributes</a> <a href="#ref-for-media-pixels①">(2)</a> <a href="#ref-for-media-pixels②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-presentedtime">
-   <b><a href="#dom-videoframemetadata-presentedtime">#dom-videoframemetadata-presentedtime</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-videoframemetadata-presentationtime">
+   <b><a href="#dom-videoframemetadata-presentationtime">#dom-videoframemetadata-presentationtime</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-videoframemetadata-presentedtime">2. VideoFrameMetadata</a>
-    <li><a href="#ref-for-dom-videoframemetadata-presentedtime①">5. Security and Privacy Considerations</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentationtime">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-presentationtime①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-expecteddisplaytime">
@@ -2266,17 +2279,11 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
     <li><a href="#ref-for-dom-videoframemetadata-height①">2.2. Attributes</a> <a href="#ref-for-dom-videoframemetadata-height②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-presentationtimestamp">
-   <b><a href="#dom-videoframemetadata-presentationtimestamp">#dom-videoframemetadata-presentationtimestamp</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dom-videoframemetadata-mediatime">
+   <b><a href="#dom-videoframemetadata-mediatime">#dom-videoframemetadata-mediatime</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-videoframemetadata-presentationtimestamp">2. VideoFrameMetadata</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-processingduration">
-   <b><a href="#dom-videoframemetadata-processingduration">#dom-videoframemetadata-processingduration</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-dom-videoframemetadata-processingduration">2. VideoFrameMetadata</a>
-    <li><a href="#ref-for-dom-videoframemetadata-processingduration①">5. Security and Privacy Considerations</a>
+    <li><a href="#ref-for-dom-videoframemetadata-mediatime">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-mediatime①">2.2. Attributes</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-presentedframes">
@@ -2285,6 +2292,13 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
     <li><a href="#ref-for-dom-videoframemetadata-presentedframes">1. Introduction</a>
     <li><a href="#ref-for-dom-videoframemetadata-presentedframes①">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-presentedframes②">4.2. Procedures</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-videoframemetadata-processingduration">
+   <b><a href="#dom-videoframemetadata-processingduration">#dom-videoframemetadata-processingduration</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-videoframemetadata-processingduration">2. VideoFrameMetadata</a>
+    <li><a href="#ref-for-dom-videoframemetadata-processingduration①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-videoframemetadata-capturetime">


### PR DESCRIPTION
This PR renames presentationTimestamp into mediaTime, and
presentedTime into presentationTime.

It marks mediaTime and presentedFrames as required.

It clarifies the circumstances under which optional fields
should be present.