### PR TITLE
Clarify behavior when video rate > composition rate

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -124,6 +124,15 @@ Presented frame 0s (1280x720) at 1000ms for display at 1016ms.
     });
   });
 ```
+* The rate at which `VideoFrameRequestCallbacks` are run is the minimum between the video rate and
+browser rate. This is because they don't fire more than once per new frame, and more than once per
+rendering steps. For example:
+| Video rate | Browser rate | VideoFrameRequestCallback rate|
+| --- | --- | --- |
+| 25fps | 60fps | 25fps |
+| 60fps | 30fps | 30fps |
+| 60fps | 60fps | 60fps |
+| 120fps | 60fps | 60fps |
 
 
 # Open Questions / Notes / Links

--- a/explainer.md
+++ b/explainer.md
@@ -127,12 +127,13 @@ Presented frame 0s (1280x720) at 1000ms for display at 1016ms.
 * The rate at which `VideoFrameRequestCallbacks` are run is the minimum between the video rate and
 browser rate. This is because they don't fire more than once per new frame, and more than once per
 rendering steps. For example:
-| Video rate | Browser rate | VideoFrameRequestCallback rate|
-| --- | --- | --- |
-| 25fps | 60fps | 25fps |
-| 60fps | 30fps | 30fps |
-| 60fps | 60fps | 60fps |
-| 120fps | 60fps | 60fps |
+
+| Video rate | Browser rate | Callback rate |
+|---|---|---|
+| **25fps** | 60hz | 25hz |
+| 60fps | **30hz** | 30hz |
+| **60fps** | **60hz** | 60hz |
+| 120fps | **60hz** | 60hz |
 
 
 # Open Questions / Notes / Links

--- a/index.bs
+++ b/index.bs
@@ -222,6 +222,14 @@ using the definitions for |docs| and |now| described in the [=update the renderi
 
 <div algorithm="run the video animation frame callbacks">
 
+Note: The effective rate at which {{VideoFrameRequestCallback|callbacks}} are run is the lesser rate
+between the video's rate and the browser's rate. When the video rate is lower than the browser rate, the
+{{VideoFrameRequestCallback|callbacks}}' rate is limited by the frequency at which new frames are
+presented. When the video rate is greater than the browser rate, the
+{{VideoFrameRequestCallback|callbacks}}' rate is limited by the frequency of the [=update the
+rendering=] steps. This means, a 25fps video playing in a browser that paints at 60hz would fire
+callbacks at 25hz; a 120fps video in that same 60hz browser would fire callbacks at 60hz.
+
 To <dfn>run the video animation frame callbacks</dfn> for a {{HTMLVideoElement}} |video| with a timestamp |now|, run the following steps:
 
 1. If |video|'s [=list of animation frame callbacks=] is empty, abort these steps.

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/video-raf/" rel="canonical">
-  <meta content="eae931a6c0d22618a7859a6c64d95a6ec5b26c00" name="document-revision">
+  <meta content="f4dded1bcb4587cd6cac40629788a853ded8b6f7" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1482,7 +1482,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">HTMLVideoElement.requestAnimationFrame()</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-03-30">30 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-04-02">2 April 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1728,6 +1728,11 @@ where and how to invoke the algorithm in the meantime.</p>
     <p>using the definitions for <var>docs</var> and <var>now</var> described in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering③">update the rendering</a> algorithm.</p>
    </div>
    <div class="algorithm" data-algorithm="run the video animation frame callbacks">
+    <p class="note" role="note"><span>Note:</span> The effective rate at which <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑦">callbacks</a></code> are run is the lesser rate
+between the video’s rate and the browser’s rate. When the video rate is lower than the browser rate, the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑧">callbacks</a></code>' rate is limited by the frequency at which new frames are
+presented. When the video rate is greater than the browser rate, the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑨">callbacks</a></code>' rate is limited by the frequency of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering④">update the
+rendering</a> steps. This means, a 25fps video playing in a browser that paints at 60hz would fire
+callbacks at 25hz; a 120fps video in that same 60hz browser would fire callbacks at 60hz.</p>
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="run-the-video-animation-frame-callbacks">run the video animation frame callbacks</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement⑦">HTMLVideoElement</a></code> <var>video</var> with a timestamp <var>now</var>, run the following steps:</p>
     <ol>
      <li data-md>
@@ -1755,11 +1760,11 @@ where and how to invoke the algorithm in the meantime.</p>
         <p>If an exception is thrown, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception" id="ref-for-report-the-exception">report the exception</a>.</p>
       </ol>
     </ol>
-    <p class="note" role="note"><span>Note:</span> There are <strong>no strict timing guarantees</strong> when it comes to how soon <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑦">callbacks</a></code> are run after a new video frame has been presented.
+    <p class="note" role="note"><span>Note:</span> There are <strong>no strict timing guarantees</strong> when it comes to how soon <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback①⓪">callbacks</a></code> are run after a new video frame has been presented.
 Consider the following scenario: a new frame is presented on the compositor thread, just as the user
 agent aborts the <a data-link-type="dfn" href="#run-the-video-animation-frame-callbacks" id="ref-for-run-the-video-animation-frame-callbacks②">algorithm</a> above, when it confirms that
-there are no new frames. We therefore won’t run the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑧">callbacks</a></code> in the <em>current</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering④">rendering steps</a>, and have to wait until the <em>next</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering⑤">rendering steps</a>, one v-sync later. In that case, visual changes to a web page made from
-within the delayed <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑨">callbacks</a></code> will appear on-screen one v-sync after the
+there are no new frames. We therefore won’t run the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback①①">callbacks</a></code> in the <em>current</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering⑤">rendering steps</a>, and have to wait until the <em>next</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering⑥">rendering steps</a>, one v-sync later. In that case, visual changes to a web page made from
+within the delayed <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback①②">callbacks</a></code> will appear on-screen one v-sync after the
 video frame does.<br> <br> Offering stricter guarantees would likely force implementers to add cross-thread synchronization, which might be detrimental to video playback performance.</p>
    </div>
    <h2 class="heading settled" data-level="5" id="security-and-privacy"><span class="secno">5. </span><span class="content">Security and Privacy Considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
@@ -2088,7 +2093,7 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">1. Introduction</a>
-    <li><a href="#ref-for-update-the-rendering①">4.2. Procedures</a> <a href="#ref-for-update-the-rendering②">(2)</a> <a href="#ref-for-update-the-rendering③">(3)</a> <a href="#ref-for-update-the-rendering④">(4)</a> <a href="#ref-for-update-the-rendering⑤">(5)</a>
+    <li><a href="#ref-for-update-the-rendering①">4.2. Procedures</a> <a href="#ref-for-update-the-rendering②">(2)</a> <a href="#ref-for-update-the-rendering③">(3)</a> <a href="#ref-for-update-the-rendering④">(4)</a> <a href="#ref-for-update-the-rendering⑤">(5)</a> <a href="#ref-for-update-the-rendering⑥">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-video-videoheight">
@@ -2329,7 +2334,7 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-1bc5c126">
     <li><a href="#ref-for-callbackdef-videoframerequestcallback④">2.2. Attributes</a>
     <li><a href="#ref-for-callbackdef-videoframerequestcallback⑤">3. VideoFrameRequestCallback</a>
     <li><a href="#ref-for-callbackdef-videoframerequestcallback⑥">4. HTMLVideoElement.requestAnimationFrame()</a>
-    <li><a href="#ref-for-callbackdef-videoframerequestcallback⑦">4.2. Procedures</a> <a href="#ref-for-callbackdef-videoframerequestcallback⑧">(2)</a> <a href="#ref-for-callbackdef-videoframerequestcallback⑨">(3)</a>
+    <li><a href="#ref-for-callbackdef-videoframerequestcallback⑦">4.2. Procedures</a> <a href="#ref-for-callbackdef-videoframerequestcallback⑧">(2)</a> <a href="#ref-for-callbackdef-videoframerequestcallback⑨">(3)</a> <a href="#ref-for-callbackdef-videoframerequestcallback①⓪">(4)</a> <a href="#ref-for-callbackdef-videoframerequestcallback①①">(5)</a> <a href="#ref-for-callbackdef-videoframerequestcallback①②">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="canceled">


### PR DESCRIPTION
This PR fixes issue #46 

The behavior is implicitly described by the current normative language. This adds a note which explicitly calls out the implicit behavior.