### PR TITLE
Document changes clear callbacks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -204,7 +204,7 @@ An {{HTMLVideoElement}} is considered to be an <dfn>associated video element</df
 <div algorithm="video-rvfc-document-change">
 
 If a {{HTMLVideoElement}}'s {{ownerDocument}} changes, the user
-agent SHOULD clear the [=list of video frame request callbacks=].
+agent MUST clear the [=list of video frame request callbacks=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -201,6 +201,13 @@ callback identifier</dfn>, which is a number which is initially zero.
 An {{HTMLVideoElement}} is considered to be an <dfn>associated video element</dfn> of a {{Document}}
 |doc| if its {{ownerDocument}} attribute is the same as |doc|.
 
+<div algorithm="video-rvfc-document-change">
+
+If a {{HTMLVideoElement}}'s {{ownerDocument}} changes, the user
+agent SHOULD clear the [=list of video frame request callbacks=].
+
+</div>
+
 <div algorithm="video-rvfc-rendering-step">
 
 Issue: This spec should eventually be merged into the HTML spec, and we should directly call [=run the

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/video-rvfc/" rel="canonical">
-  <meta content="7ead0fa025d85d2a821c0f66e4b9021415bd2ed9" name="document-revision">
+  <meta content="f579f72e6cc3b5a6df450b2496491c82c903fc48" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1482,7 +1482,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">HTMLVideoElement.requestVideoFrameCallback()</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-04-10">10 April 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-04-27">27 April 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1711,6 +1711,10 @@ callback identifier</dfn>, which is a number which is initially zero.</p>
    </dl>
    <h3 class="heading settled" data-level="4.2" id="video-rvfc-procedures"><span class="secno">4.2. </span><span class="content">Procedures</span><a class="self-link" href="#video-rvfc-procedures"></a></h3>
    <p>An <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement⑥">HTMLVideoElement</a></code> is considered to be an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="associated-video-element">associated video element</dfn> of a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> <var>doc</var> if its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-ownerdocument" id="ref-for-dom-node-ownerdocument③">ownerDocument</a></code> attribute is the same as <var>doc</var>.</p>
+   <div class="algorithm" data-algorithm="video-rvfc-document-change">
+    <p>If a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement⑦">HTMLVideoElement</a></code>'s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-node-ownerdocument" id="ref-for-dom-node-ownerdocument④">ownerDocument</a></code> changes, the user
+agent SHOULD clear the <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks③">list of video frame request callbacks</a>.</p>
+   </div>
    <div class="algorithm" data-algorithm="video-rvfc-rendering-step">
     <p class="issue" id="issue-9a108000"><a class="self-link" href="#issue-9a108000"></a> This spec should eventually be merged into the HTML spec, and we should directly call <a data-link-type="dfn" href="#run-the-video-frame-request-callbacks" id="ref-for-run-the-video-frame-request-callbacks">run the
 video frame request callbacks</a> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering①">update the rendering</a> steps. This procedure describes
@@ -1734,10 +1738,10 @@ the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframereque
 presented. When the video rate is greater than the browser rate, the <code class="idl"><a data-link-type="idl" href="#callbackdef-videoframerequestcallback" id="ref-for-callbackdef-videoframerequestcallback⑨">callbacks</a></code>' rate is limited by the frequency of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering④">update the
 rendering</a> steps. This means, a 25fps video playing in a browser that paints at 60hz would fire
 callbacks at 25hz; a 120fps video in that same 60hz browser would fire callbacks at 60hz.</p>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="run-the-video-frame-request-callbacks">run the video frame request callbacks</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement⑦">HTMLVideoElement</a></code> <var>video</var> with a timestamp <var>now</var>, run the following steps:</p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="run-the-video-frame-request-callbacks">run the video frame request callbacks</dfn> for a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement" id="ref-for-htmlvideoelement⑧">HTMLVideoElement</a></code> <var>video</var> with a timestamp <var>now</var>, run the following steps:</p>
     <ol>
      <li data-md>
-      <p>If <var>video</var>’s <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks③">list of video frame request callbacks</a> is empty, abort these steps.</p>
+      <p>If <var>video</var>’s <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks④">list of video frame request callbacks</a> is empty, abort these steps.</p>
      <li data-md>
       <p>Let <var>metadata</var> be the <code class="idl"><a data-link-type="idl" href="#dictdef-videoframemetadata" id="ref-for-dictdef-videoframemetadata②">VideoFrameMetadata</a></code> dictionary built from <var>video</var>’s latest presented frame.</p>
      <li data-md>
@@ -1747,9 +1751,9 @@ callbacks at 25hz; a 120fps video in that same 60hz browser would fire callbacks
      <li data-md>
       <p>Set the <a data-link-type="dfn" href="#last-presented-frame-indentifier" id="ref-for-last-presented-frame-indentifier①">last presented frame indentifier</a> to <var>presentedFrames</var>.</p>
      <li data-md>
-      <p>Let <var>callbacks</var> be the <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks④">list of video frame request callbacks</a>.</p>
+      <p>Let <var>callbacks</var> be the <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks⑤">list of video frame request callbacks</a>.</p>
      <li data-md>
-      <p>Set <var>video</var>’s <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks⑤">list of video frame request callbacks</a> to be empty.</p>
+      <p>Set <var>video</var>’s <a data-link-type="dfn" href="#list-of-video-frame-request-callbacks" id="ref-for-list-of-video-frame-request-callbacks⑥">list of video frame request callbacks</a> to be empty.</p>
      <li data-md>
       <p>For each entry in <var>callbacks</var></p>
       <ol>
@@ -2014,7 +2018,7 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
    <a href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">https://dom.spec.whatwg.org/#dom-node-ownerdocument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-ownerdocument">4.1. Methods</a> <a href="#ref-for-dom-node-ownerdocument①">(2)</a> <a href="#ref-for-dom-node-ownerdocument②">(3)</a>
-    <li><a href="#ref-for-dom-node-ownerdocument③">4.2. Procedures</a>
+    <li><a href="#ref-for-dom-node-ownerdocument③">4.2. Procedures</a> <a href="#ref-for-dom-node-ownerdocument④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
@@ -2044,7 +2048,7 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
     <li><a href="#ref-for-htmlvideoelement">1. Introduction</a>
     <li><a href="#ref-for-htmlvideoelement①">4. HTMLVideoElement.requestVideoFrameCallback()</a>
     <li><a href="#ref-for-htmlvideoelement②">4.1. Methods</a> <a href="#ref-for-htmlvideoelement③">(2)</a> <a href="#ref-for-htmlvideoelement④">(3)</a> <a href="#ref-for-htmlvideoelement⑤">(4)</a>
-    <li><a href="#ref-for-htmlvideoelement⑥">4.2. Procedures</a> <a href="#ref-for-htmlvideoelement⑦">(2)</a>
+    <li><a href="#ref-for-htmlvideoelement⑥">4.2. Procedures</a> <a href="#ref-for-htmlvideoelement⑦">(2)</a> <a href="#ref-for-htmlvideoelement⑧">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-canvas">
@@ -2349,7 +2353,7 @@ where and how to invoke the algorithm in the meantime.<a href="#issue-9a108000">
    <b><a href="#list-of-video-frame-request-callbacks">#list-of-video-frame-request-callbacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-video-frame-request-callbacks">4.1. Methods</a> <a href="#ref-for-list-of-video-frame-request-callbacks①">(2)</a> <a href="#ref-for-list-of-video-frame-request-callbacks②">(3)</a>
-    <li><a href="#ref-for-list-of-video-frame-request-callbacks③">4.2. Procedures</a> <a href="#ref-for-list-of-video-frame-request-callbacks④">(2)</a> <a href="#ref-for-list-of-video-frame-request-callbacks⑤">(3)</a>
+    <li><a href="#ref-for-list-of-video-frame-request-callbacks③">4.2. Procedures</a> <a href="#ref-for-list-of-video-frame-request-callbacks④">(2)</a> <a href="#ref-for-list-of-video-frame-request-callbacks⑤">(3)</a> <a href="#ref-for-list-of-video-frame-request-callbacks⑥">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="last-presented-frame-indentifier">


### PR DESCRIPTION
This PR adds a small amount of text mentioning that UAs should clear the callbacks if a Document changes.

The main problem if the callbacks aren't cleared would be that there is a collision between callback IDs, which are per Document and not per element. This could be SHOULD instead of MUST.